### PR TITLE
Support IPv4-only platforms

### DIFF
--- a/ngx_http_ip_tos_filter_module.c
+++ b/ngx_http_ip_tos_filter_module.c
@@ -96,12 +96,14 @@ ngx_http_ip_tos_header_filter(ngx_http_request_t *r)
 			"setsockopt(IP_TOS) failed");
 	}
     }else{
+#ifdef IPPROTO_IPV6
       if(setsockopt(r->connection->fd, IPPROTO_IPV6, IPV6_TCLASS, &tos, sizeof(tos)) == -1)
 	{
 	  ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_socket_errno,
 			"setsockopt(IPV6_TCLASS) failed");
 	  
 	}
+#endif
     }
     return ngx_http_next_header_filter(r);
 }


### PR DESCRIPTION
Support building in an IPv4-only configuration,
as might be found on small, non-internet routable
WLAN devices.